### PR TITLE
Update package.json to fix "cannot find module jade" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "devDependencies": {
     "coffee-script": "^1.7.1",
     "grunt-contrib-coffee": "^0.10.1",
-    "jade": "^1.3.1",
-    "lodash": "^2.4.1"
+  },
+  "dependencies": {
+    "jade": "^1.11.0",
+    "lodash": "^3.10.0"
   }
 }


### PR DESCRIPTION
Move dependencies needed by assemble-jade into `"dependencies"` block. Leave dependencies uses for making a build into `"devDependencies"`.
